### PR TITLE
Getting release version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get clean
 RUN git config --global --add safe.directory /build
 
 WORKDIR /root
-ENV MAVEN_VERSION 3.9.2
+ENV MAVEN_VERSION 3.9.3
 RUN wget https://downloads.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
 RUN tar -xvzf apache-maven-$MAVEN_VERSION-bin.tar.gz
 COPY ./mvn-build /root/bin/mvn-build

--- a/mvn-release
+++ b/mvn-release
@@ -5,6 +5,7 @@ set -eu
 E_BAD_ARGS=66
 
 mvn --batch-mode clean
+mvn --batch-mode release:prepare -DdryRun
+mvn --batch-mode help:evaluate -f pom.xml.tag -Dexpression=project.version -q -DforceStdout > .version
 mvn --batch-mode release:prepare
 mvn --batch-mode release:perform
-mvn --batch-mode help:evaluate -Dexpression=project.version -q -DforceStdout > .version


### PR DESCRIPTION
[Card](https://rentgroup.atlassian.net/browse/SRV-5465)

During the release:prepare goal, the version in the pom file is updated twice, once to remove ‘SNAPSHOT’ from the version and another time to increment and add ‘SNAPSHOT’ back for the next development cycle. By preparing the release as a dry run first, we are able to get the correct release version from the prepare goal (before it is incremented for the next development cycle) and use that for the github release version. Everything from the dry run is cleaned up at the end of the release:preform goal.