### PR TITLE
Do not resume previous prepare attempt

### DIFF
--- a/mvn-release
+++ b/mvn-release
@@ -7,5 +7,5 @@ E_BAD_ARGS=66
 mvn --batch-mode clean
 mvn --batch-mode release:prepare -DdryRun
 mvn --batch-mode help:evaluate -f pom.xml.tag -Dexpression=project.version -q -DforceStdout > .version
-mvn --batch-mode release:prepare
+mvn --batch-mode release:prepare -Dresume=false
 mvn --batch-mode release:perform


### PR DESCRIPTION
[Card](https://rentgroup.atlassian.net/browse/SRV-5465)

Preparing the release as a dryrun creates a SNAPSHOT jar, and when preparing the release again, it simply picks up the previous prepare; instead, We want to prepare the release from scratch so that it correctly creates the release jar.